### PR TITLE
Fix: The mastery dust progress bar had no colour

### DIFF
--- a/game/src/components/tabs/Mastery.svelte
+++ b/game/src/components/tabs/Mastery.svelte
@@ -168,4 +168,8 @@ function toggleMasteryUseLogScale() {
     --tw-bg-opacity: 1;
     background-color: rgb(226 232 240 / var(--tw-bg-opacity))
 }
+.bg-indigo-600 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(79 70 229 / var(--tw-bg-opacity))
+}
 </style>


### PR DESCRIPTION
This is a small hotfix for the dust progress bar in mastery.